### PR TITLE
remove the rule that cacheable methods must not be transactional 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 kotlin.code.style=official
 
-version=0.1.1
+version=0.2.0

--- a/rules/spring.md
+++ b/rules/spring.md
@@ -106,17 +106,6 @@ Whenever you access the database via Spring Data repositories, ensure you are wi
 from a method that is annotated with `@Transactional`) to ensure ACID criteria when reading data from the DB. In case
 you are only reading from the database (and not writing), consider to use `@Transactional(readOnly=true)`
 
-<a id="tx-transactional-methods-should-not-be-cacheable"></a>
-### Functions should not be  @Transactional and @Cacheable
-<sup>`Rule-ID: spring.tx-transactional-methods-should-not-be-cacheable`</sup>
-
-The `@Cacheable` Annotation enables a caching optimization for the corresponding function call.
-When applied the function may return a cached result from an earlier call, instead of actually evaluating the function.
-Hence, a `@Cacheable` function should not have side effects!
-
-The `@Transactional` annotation opens database transactions.
-Transactions bundle several write operations so that they apply atomically. In case of an error, they will be rolled back collectively.
-
 <a id="tx-do-not-throw-exceptions"></a>
 ### @Transactional annotated methods must not throw checked exceptions
 <sup>`Rule-ID: spring.tx-do-not-throw-exceptions`</sup>

--- a/src/main/kotlin/io/cloudflight/cleancode/archunit/rules/spring/SpringTransactionalRules.kt
+++ b/src/main/kotlin/io/cloudflight/cleancode/archunit/rules/spring/SpringTransactionalRules.kt
@@ -69,14 +69,6 @@ class SpringTransactionalRules {
         )
 
 
-    @ArchTest
-    val methods_that_are_transactional_should_not_be_cacheable =
-        archRuleWithId(
-            "spring.tx-transactional-methods-should-not-be-cacheable",
-            methods()
-                .that(AreTransactional())
-                .should(NotBeCacheable())
-        )
 
     private class NotBeCacheable :
         ArchCondition<JavaMethod>("not be annotated with @Cacheable") {

--- a/src/test/kotlin/io/cloudflight/cleancode/archunit/rules/spring/CloudflightSpringTransactionalRulesTest.kt
+++ b/src/test/kotlin/io/cloudflight/cleancode/archunit/rules/spring/CloudflightSpringTransactionalRulesTest.kt
@@ -44,8 +44,6 @@ class CloudflightSpringTransactionalRulesTest {
             assertThat(e.message!!.split("\n").size).isEqualTo(3)
         }
 
-
-        rules.methods_that_are_transactional_should_not_be_cacheable.check(importerGoodCases)
         rulesRepository.repository_methods_should_only_be_accessed_by_transactional_methods.check(importerGoodCases)
     }
 
@@ -76,11 +74,6 @@ class CloudflightSpringTransactionalRulesTest {
 
         assertThrows<AssertionError> {
             rulesRepository.methods_that_are_transactional_should_access_other_transactional_methods_or_repositories
-                .check(importerBadCases)
-        }
-
-        assertThrows<AssertionError> {
-            rules.methods_that_are_transactional_should_not_be_cacheable
                 .check(importerBadCases)
         }
 


### PR DESCRIPTION
thiis can better be solved be ensuring the order of @EnableCaching and @EnableTransactionManagement