### PR TITLE
major: upgrade versions to prepare for java 21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
 
-junit = "5.8.2"
-spring = "6.0.3"
-springboot = "3.0.2"
-springdata = "3.0.0"
+junit = "5.10.1"
+spring = "6.1.4"
+springboot = "3.2.3"
+springdata = "3.2.3"
 
 [libraries]
-archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version = "1.0.1" }
+archunit-junit5 = { module = "com.tngtech.archunit:archunit-junit5", version = "1.2.1" }
 
 jakarta-persistence-api = { module = "jakarta.persistence:jakarta.persistence-api", version = "3.1.0" }
 jakarta-validation-api = { module = "jakarta.validation:jakarta.validation-api", version = "3.0.2" }
@@ -14,9 +14,9 @@ jakarta-transaction-api = { module = "jakarta.transaction:jakarta.transaction-ap
 
 junit = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-params = { module = "org.junit.jupiter:junit-jupiter-params", version = "junit" }
-assertj = { module = "org.assertj:assertj-core", version = "3.23.1" }
+assertj = { module = "org.assertj:assertj-core", version = "3.25.3" }
 
-kotlin-logging = { module = "io.github.microutils:kotlin-logging", version = "1.7.9" }
+kotlin-logging = { module = "io.github.microutils:kotlin-logging", version = "3.0.5" }
 
 spring-context = { module = "org.springframework:spring-context", version.ref = "spring" }
 spring-tx = { module = "org.springframework:spring-tx", version.ref = "spring" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("io.cloudflight.autoconfigure-settings") version "0.9.1"
+    id("io.cloudflight.autoconfigure-settings") version "1.1.1"
 }
 
 rootProject.name = "archunit-cleancode-verifier"


### PR DESCRIPTION
In order to use Java 21, we need to use the latest archunit version, which can also deal with java 21 class files. Besides that, all other versions are upgraded to the latest or corresponding versions